### PR TITLE
Add command to directly deploy to GitHub Pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ _Note: Cette [extension VSCode](https://marketplace.visualstudio.com/items?itemN
 
 - `npm run build` compile le projet dans le dossier `dist`.
 - `npm run serve` lance un serveur local du build de production.
+- `npm run pages` déploie le dossier `dist` sur GitHub Pages.
 
 ## Contribute
 

--- a/package.json
+++ b/package.json
@@ -3,11 +3,13 @@
   "scripts": {
     "dev": "cross-env TAILWIND_MODE=watch vite",
     "build": "cross-env TAILWIND_MODE=build vite build",
-    "serve": "vite preview"
+    "serve": "vite preview",
+    "pages": "gh-pages -d dist"
   },
   "devDependencies": {
     "autoprefixer": "^10.4.13",
     "cross-env": "^7.0.3",
+    "gh-pages": "^4.0.0",
     "postcss": "^8.4.20",
     "tailwindcss": "^3.2.4",
     "vite": "^2.4.4"

--- a/vite.config.js
+++ b/vite.config.js
@@ -4,6 +4,7 @@ import { resolve } from "path";
 // https://vitejs.dev/config/
 export default defineConfig({
   root: "src",
+  base: "",
   build: {
     rollupOptions: {
       input: {


### PR DESCRIPTION
This PR adds an npm command to deploy the `dist` folder to GitHub Pages.